### PR TITLE
Use ModelType as Row type when no select is called

### DIFF
--- a/src/typedKnex.ts
+++ b/src/typedKnex.ts
@@ -14,8 +14,8 @@ export class TypedKnex {
 
     constructor(private knex: Knex) { }
 
-    public query<T>(tableClass: new () => T): ITypedQueryBuilder<T, {}> {
-        return new TypedQueryBuilder<T>(tableClass, this.knex);
+    public query<T>(tableClass: new () => T): ITypedQueryBuilder<T, T> {
+        return new TypedQueryBuilder<T, T>(tableClass, this.knex);
     }
 }
 
@@ -37,8 +37,8 @@ export function registerBeforeUpdateTransform<T>(f: (item: T, typedQueryBuilder:
 export interface ITypedQueryBuilder<ModelType, Row> {
     where: IWhere<ModelType, Row>;
     //     whereNot: IWhere<ModelType, Row>;
-    selectColumns: ISelectColumns<ModelType, Row>;
-    selectColumn: ISelectColumn<ModelType, Row>;
+    selectColumns: ISelectColumns<ModelType, Row extends ModelType ? {} : Row>;
+    selectColumn: ISelectColumn<ModelType, Row extends ModelType ? {} : Row>;
     orderBy: IKeysAsParametersReturnQueryBuider<ModelType, Row>;
     innerJoinColumn: IKeysAsParametersReturnQueryBuider<ModelType, Row>;
     leftOuterJoinColumn: IKeysAsParametersReturnQueryBuider<ModelType, Row>;


### PR DESCRIPTION
When a query without selectColumn or selectColumns is performed, the result is typed as {}. But actually by default all columns are selected (select *).

This PR changes it so:
- when no selectColumn or selectColumns call is done, the Row type defaults to ModelType. This correctly represents all columns being selected.
- when a selectColumn or selectColumns call is added, this default is disregarded.