### PR TITLE
Reflect metadata cannot read tablename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 4.5.2
+
+- Attach `tableMetadataKey` and `tableColumns` references to the `Table` class prototypes
+  - This fixes a rare and unique issue where the same `Column`s and `Table`s can get registered multiple times as a side-effect of overenthusiatic tree-shaking
+
+## 4.5.1
+
+- Fix deployment issue where `dist` was not updated to 4.5.0 changes
+
 ## 4.5.0
 
 - Feature: added `updateItemWithReturning`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wwwouter/typed-knex",
-    "version": "4.5.0",
+    "version": "4.5.2",
     "description": "Makes knex better by working with TypeScript",
     "dependencies": {
         "flat": "5.0.2",

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -46,9 +46,8 @@ export function getTableMetadata(tableClass: Function): { tableName: string } {
     return Reflect.getMetadata(tableyMetadataKey, tableClass);
 }
 
-
 export function getTableName(tableClass: Function): string {
-    return Reflect.getMetadata(tableyMetadataKey, tableClass).tableName;
+    return getTableMetadata(tableClass).tableName
 }
 
 export function getColumnName<T>(tableClass: new () => T, propertyName: keyof T): string {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -30,7 +30,7 @@ export function getEntities() {
 
 export function Entity(tableName?: string) {
     return (target: Function) => {
-        target.prototype.tableMetadataKey = Symbol('table')
+        target.prototype.tableMetadataKey = Symbol('table');
         Reflect.metadata(target.prototype.tableMetadataKey, { tableName: tableName ?? target.name })(target);
 
         entities.push({ tableName: tableName ?? target.name, entityClass: target });
@@ -45,7 +45,7 @@ export function getTableMetadata(tableClass: Function): { tableName: string } {
 }
 
 export function getTableName(tableClass: Function): string {
-    return getTableMetadata(tableClass).tableName
+    return getTableMetadata(tableClass).tableName;
 }
 
 export function getColumnName<T>(tableClass: new () => T, propertyName: keyof T): string {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,7 +1,5 @@
 import 'reflect-metadata';
 
-const tableyMetadataKey = Symbol('table');
-
 interface IColumnData {
     name: string;
     primary: boolean;
@@ -9,7 +7,6 @@ interface IColumnData {
     isForeignKey: boolean;
     designType: any;
 }
-const tableColumns = new Map<Function, IColumnData[]>();
 
 const entities = [] as {
     tableName: string;
@@ -33,7 +30,8 @@ export function getEntities() {
 
 export function Entity(tableName?: string) {
     return (target: Function) => {
-        Reflect.metadata(tableyMetadataKey, { tableName: tableName ?? target.name })(target);
+        target.prototype.tableMetadataKey = Symbol('table')
+        Reflect.metadata(target.prototype.tableMetadataKey, { tableName: tableName ?? target.name })(target);
 
         entities.push({ tableName: tableName ?? target.name, entityClass: target });
     };
@@ -43,7 +41,7 @@ export function Entity(tableName?: string) {
 export const Table = Entity;
 
 export function getTableMetadata(tableClass: Function): { tableName: string } {
-    return Reflect.getMetadata(tableyMetadataKey, tableClass);
+    return Reflect.getMetadata(tableClass.prototype.tableMetadataKey, tableClass);
 }
 
 export function getTableName(tableClass: Function): string {
@@ -109,7 +107,7 @@ function getRegisterColumn(options?: IColumnOptions) {
             false
             : false;
 
-        const columns = tableColumns.get(target.constructor) || [];
+        const columns: IColumnData[] = target.constructor.prototype.tableColumns || [];
 
         let name = propertyKey;
         // console.log('name: ', name);
@@ -123,7 +121,7 @@ function getRegisterColumn(options?: IColumnOptions) {
         }
 
         columns.push({ name, primary, propertyKey, isForeignKey, designType });
-        tableColumns.set(target.constructor, columns);
+        target.constructor.prototype.tableColumns = columns;
     }
 
     return registerColumn;
@@ -162,7 +160,7 @@ export function getColumnInformation(
 }
 
 export function getColumnProperties(tableClass: Function): IColumnData[] {
-    const columns = tableColumns.get(tableClass);
+    const columns: IColumnData[] = tableClass.prototype.tableColumns;
     if (!columns) {
         throw new Error(
             `Cannot get column data from ${tableClass.constructor.name
@@ -174,7 +172,7 @@ export function getColumnProperties(tableClass: Function): IColumnData[] {
 
 export function getPrimaryKeyColumn(tableClass: Function): IColumnData {
     // console.log('tableClass: ', tableClass);
-    const columns = tableColumns.get(tableClass);
+    const columns: IColumnData[] = tableClass.prototype.tableColumns;
     if (!columns) {
         throw new Error(
             `Cannot get column data from ${tableClass.constructor.name

--- a/src/typedKnex.ts
+++ b/src/typedKnex.ts
@@ -1,6 +1,6 @@
 // tslint:disable:use-named-parameter
 import { Knex } from "knex";
-import { getColumnInformation, getColumnProperties, getPrimaryKeyColumn, getTableMetadata } from "./decorators";
+import { getColumnInformation, getColumnProperties, getPrimaryKeyColumn, getTableName } from "./decorators";
 import { mapObjectToTableObject } from "./mapObjectToTableObject";
 import { NestedForeignKeyKeysOf, NestedKeysOf } from "./NestedKeysOf";
 import { NestedRecord } from "./NestedRecord";
@@ -478,7 +478,7 @@ class TypedQueryBuilder<ModelType, SelectableModel, Row = {}> implements ITypedQ
     private subQueryCounter = 0;
 
     constructor(private tableClass: new () => ModelType, private knex: Knex, queryBuilder?: Knex.QueryBuilder, private parentTypedQueryBuilder?: any, private subQueryPrefix?: string) {
-        this.tableName = getTableMetadata(tableClass).tableName;
+        this.tableName = getTableName(tableClass);
         this.columns = getColumnProperties(tableClass);
 
         if (queryBuilder !== undefined) {
@@ -885,7 +885,7 @@ class TypedQueryBuilder<ModelType, SelectableModel, Row = {}> implements ITypedQ
         });
 
         const tableToJoinClass = newPropertyType;
-        const tableToJoinName = getTableMetadata(tableToJoinClass).tableName;
+        const tableToJoinName = getTableName(tableToJoinClass);
         const tableToJoinAlias = newPropertyKey;
 
         const table1Column = this.getColumnName(...column1Parts);
@@ -924,7 +924,7 @@ class TypedQueryBuilder<ModelType, SelectableModel, Row = {}> implements ITypedQ
         });
 
         const tableToJoinClass = newPropertyType;
-        const tableToJoinName = getTableMetadata(tableToJoinClass).tableName;
+        const tableToJoinName = getTableName(tableToJoinClass);
         const tableToJoinAlias = newPropertyKey;
 
         const table1Column = this.getColumnName(...column1Parts);
@@ -1313,7 +1313,7 @@ class TypedQueryBuilder<ModelType, SelectableModel, Row = {}> implements ITypedQ
     }
 
     public async insertSelect() {
-        const tableName = getTableMetadata(arguments[0]).tableName;
+        const tableName = getTableName(arguments[0]);
 
         const typedQueryBuilderForInsert = new TypedQueryBuilder<any, any>(arguments[0], this.knex);
         let columnArgumentsList;
@@ -1486,7 +1486,7 @@ class TypedQueryBuilder<ModelType, SelectableModel, Row = {}> implements ITypedQ
             secondColumnClass = columnInfo.columnClass;
         }
 
-        const tableToJoinName = getTableMetadata(secondColumnClass).tableName;
+        const tableToJoinName = getTableName(secondColumnClass);
         const tableToJoinAlias = `${this.subQueryPrefix ?? ""}${secondColumnAlias}`;
         const tableToJoinJoinColumnName = `${tableToJoinAlias}.${getPrimaryKeyColumn(secondColumnClass).name}`;
 
@@ -1563,7 +1563,7 @@ class TypedQueryBuilder<ModelType, SelectableModel, Row = {}> implements ITypedQ
         });
 
         const tableToJoinClass = newPropertyType;
-        const tableToJoinName = getTableMetadata(tableToJoinClass).tableName;
+        const tableToJoinName = getTableName(tableToJoinClass);
         const tableToJoinAlias = newPropertyKey;
 
         let knexOnObject: any;
@@ -1674,7 +1674,7 @@ class TypedQueryBuilder<ModelType, SelectableModel, Row = {}> implements ITypedQ
 
         const tableToJoinAliasWithUnderscores = tableToJoinAlias.split(".").join("_");
 
-        const tableToJoinName = getTableMetadata(tableToJoinClass).tableName;
+        const tableToJoinName = getTableName(tableToJoinClass);
 
         const joinTableColumnInformation = getColumnInformation(tableToJoinClass, joinTableColumnString);
 


### PR DESCRIPTION
Fix for issue #42 

- Attach `tableMetadataKey` and `tableColumns` references to the `Table` class prototypes
  - This fixes a rare and unique issue where the same `Column`s and `Table`s can get registered multiple times as a side-effect of overenthusiatic tree-shaking
- Use pre-established reusable `getTableName` function to simplify accessing class table name
  
No additional unit tests have been created here due to uniqueness and reproduction difficulties. However all 180 test are passing in this PR. I also recognize not all this follows the patterns as established in [CONTRIBUTING.md](https://github.com/wwwouter/typed-knex/blob/master/CONTRIBUTING.md), but as far as I can tell, neither has an PRs of recent history