### PR TITLE
Added `selectRaw` string bindings; Added `orWhereParentheses`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 4.12.0
 
 -   Feature: Added bindings argument to `selectRaw` to utilize knex raw string bindings
+-   Added `orWhereParentheses`
 
 ## 4.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 -   Chore: Fix links to Knex.js documentation.
 
+## 4.12.0
+
+-   Feature: Added bindings argument to `selectRaw` to utilize knex raw string bindings
+
 ## 4.11.0
 
 -   Feature: Added `getKnexQueryBuilder`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@wwwouter/typed-knex",
-    "version": "4.9.1",
+    "version": "4.12.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@wwwouter/typed-knex",
-            "version": "4.9.1",
+            "version": "4.12.0",
             "license": "MIT",
             "dependencies": {
                 "flat": "5.0.2",
@@ -22,7 +22,7 @@
                 "@types/chai-as-promised": "7.1.5",
                 "@types/flat": "5.0.2",
                 "@types/mocha": "9.1.1",
-                "@types/node": "^18.0.0",
+                "@types/node": "18.0.0",
                 "@types/yargs": "17.0.10",
                 "@typescript-eslint/eslint-plugin": "5.28.0",
                 "@typescript-eslint/parser": "5.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wwwouter/typed-knex",
-    "version": "4.11.0",
+    "version": "4.12.0",
     "description": "Makes knex better by working with TypeScript",
     "dependencies": {
         "flat": "5.0.2",

--- a/src/typedKnex.ts
+++ b/src/typedKnex.ts
@@ -265,12 +265,7 @@ interface IJoin<Model, _SelectableModel, Row> {
 }
 
 interface ISelectRaw<Model, SelectableModel, Row> {
-    <TReturn extends Boolean | String | Number, TName extends keyof any>(
-        name: TName,
-        returnType: IConstructor<TReturn>,
-        query: string,
-        ...bindings: string[]
-    ): ITypedQueryBuilder<
+    <TReturn extends Boolean | String | Number, TName extends keyof any>(name: TName, returnType: IConstructor<TReturn>, query: string, ...bindings: string[]): ITypedQueryBuilder<
         Model,
         SelectableModel,
         Record<TName, ObjectToPrimitive<TReturn>> & Row
@@ -882,7 +877,7 @@ export class TypedQueryBuilder<ModelType, SelectableModel, Row = {}> implements 
 
     public selectRaw() {
         this.hasSelectClause = true;
-        const [name, _, query, ...bindings] = Array.from(arguments)
+        const [name, _, query, ...bindings] = Array.from(arguments);
 
         this.queryBuilder.select(this.knex.raw(`(${query}) as "${name}"`, bindings));
         return this as any;

--- a/src/typedKnex.ts
+++ b/src/typedKnex.ts
@@ -101,6 +101,7 @@ export interface ITypedQueryBuilder<Model, SelectableModel, Row> {
     orWhereNotExists: IWhereExists<Model, SelectableModel, Row>;
 
     whereParentheses: IWhereParentheses<Model, SelectableModel, Row>;
+    orWhereParentheses: IWhereParentheses<Model, SelectableModel, Row>;
 
     groupBy: ISelectableColumnKeyFunctionAsParametersReturnQueryBuider<Model, SelectableModel, Row>;
 
@@ -1137,6 +1138,11 @@ export class TypedQueryBuilder<ModelType, SelectableModel, Row = {}> implements 
 
     public whereParentheses() {
         this.callQueryCallbackFunction("where", this.tableClass, arguments[0]);
+
+        return this;
+    }
+    public orWhereParentheses() {
+        this.callQueryCallbackFunction("orWhere", this.tableClass, arguments[0]);
 
         return this;
     }

--- a/src/typedKnex.ts
+++ b/src/typedKnex.ts
@@ -265,7 +265,12 @@ interface IJoin<Model, _SelectableModel, Row> {
 }
 
 interface ISelectRaw<Model, SelectableModel, Row> {
-    <TReturn extends Boolean | String | Number, TName extends keyof any>(name: TName, returnType: IConstructor<TReturn>, query: string): ITypedQueryBuilder<
+    <TReturn extends Boolean | String | Number, TName extends keyof any>(
+        name: TName,
+        returnType: IConstructor<TReturn>,
+        query: string,
+        ...bindings: string[]
+    ): ITypedQueryBuilder<
         Model,
         SelectableModel,
         Record<TName, ObjectToPrimitive<TReturn>> & Row
@@ -877,10 +882,9 @@ export class TypedQueryBuilder<ModelType, SelectableModel, Row = {}> implements 
 
     public selectRaw() {
         this.hasSelectClause = true;
-        const name = arguments[0];
-        const query = arguments[2];
+        const [name, _, query, ...bindings] = Array.from(arguments)
 
-        this.queryBuilder.select(this.knex.raw(`(${query}) as "${name}"`));
+        this.queryBuilder.select(this.knex.raw(`(${query}) as "${name}"`, bindings));
         return this as any;
     }
 

--- a/test/unit/typedQueryBuilderTests.ts
+++ b/test/unit/typedQueryBuilderTests.ts
@@ -335,6 +335,15 @@ describe("TypedKnexQueryBuilder", () => {
         done();
     });
 
+    it("should select raw query with sql bindings", (done) => {
+        const typedKnex = new TypedKnex(knex({ client: "postgresql" }));
+        const query = typedKnex.query(User).selectRaw("subQuery", Number, "select ?? from other where ?? like ?", "other.id", "other.name", "%test%");
+        const queryString = query.toQuery();
+        assert.equal(queryString, 'select (select "other"."id" from other where "other"."name" like \'%test%\') as "subQuery" from "users"');
+
+        done();
+    });
+
     it("should create query with AND in where clause", (done) => {
         const typedKnex = new TypedKnex(knex({ client: "postgresql" }));
         const query = typedKnex.query(User).where("name", "user1").andWhere("name", "user2").andWhere("name", "like", "%user%");

--- a/test/unit/typedQueryBuilderTests.ts
+++ b/test/unit/typedQueryBuilderTests.ts
@@ -824,6 +824,19 @@ describe("TypedKnexQueryBuilder", () => {
         done();
     });
 
+    it("should create query with parentheses in orWhere", (done) => {
+        const typedKnex = new TypedKnex(knex({ client: "postgresql" }));
+        const query = typedKnex
+            .query(User)
+            .where("name", "=", "Tester")
+            .orWhereParentheses((sub) => sub.whereNotNull("someNullableValue").andWhere("numericValue", ">", 20));
+
+        const queryString = query.toQuery();
+        assert.equal(queryString, 'select * from "users" where "users"."name" = \'Tester\' or ("users"."someNullableValue" is not null and "users"."numericValue" > 20)');
+
+        done();
+    });
+
     it("should return metadata from tables", (done) => {
         const tables = getTables();
 


### PR DESCRIPTION
My project uses this package a ton, and we recently realized that one of our major calls was susceptible to sql injection. The culprit is an interpolated string being used in `selectRaw`. By adding knew.raw string bindings to the function, we can use knex's built-in sql injection handling.

I also added the `orWhereParentheses` implementation as not having this is preventing us from executing some complicated filtering logic